### PR TITLE
merge feature/fixes into develop

### DIFF
--- a/src/std.hpp
+++ b/src/std.hpp
@@ -27,6 +27,7 @@
 #include <std/utility/forward.hpp>
 #include <std/utility/move.hpp>
 #include <std/utility/pair.hpp>
+#include <std/utility/remove_reference.hpp>
 
 // DEFINITIONS
 #include <std/stddef.hpp>

--- a/src/std/container/dynamic/base.hpp
+++ b/src/std/container/dynamic/base.hpp
@@ -291,7 +291,7 @@ protected:
     bool shift_left(std::iterator<object_type> position, std::size_t count)
     {
         // Validate position.
-        if(position < base::m_begin || position >= base::m_end)
+        if(position < base::m_begin || position > base::m_end)
         {
             return false;
         }

--- a/src/std/container/dynamic/base.hpp
+++ b/src/std/container/dynamic/base.hpp
@@ -147,43 +147,25 @@ public:
         // Reset end iterator.
         base::m_end = base::m_begin;
     }
+    /// \brief Swaps the contents of this container with another container.
+    /// \param[in] other The other container to swap with.
+    void swap(std::container::dynamic::base<object_type>& other)
+    {
+        // Store this container's pointers in a temporary.
+        auto temp_begin = base::m_begin;
+        auto temp_end = base::m_end;
+        auto temp_capacity = base::m_capacity;
 
-    // CAPACITY
-    /// \brief Gets the size of the container.
-    /// \return The size of the container.
-    std::size_t size() const
-    {
-        return base::m_end - base::m_begin;
-    }
-    /// \brief Gets the maximum capacity of the container.
-    /// \return The capacity of the container.
-    std::size_t capacity() const
-    {
-        return base::m_capacity - base::m_begin;
-    }
-    /// \brief Checks if the container is empty.
-    /// \return TRUE if the container is empty, otherwise FALSE.
-    bool empty() const
-    {
-        return base::m_end == base::m_begin;
-    }
-    /// \brief Checks if the container is at capacity.
-    /// \return TRUE if the container is at capacity, otherwise FALSE.
-    bool full() const
-    {
-        return base::m_end == base::m_capacity;
-    }
+        // Store the other container's pointers in this container.
+        base::m_begin = other.m_begin;
+        base::m_end = other.m_end;
+        base::m_capacity = other.m_capacity;
 
-protected:
-    // MEMORY
-    /// \brief Stores a pointer to the beginning of the container's contiguous memory.
-    object_type* m_begin;
-    /// \brief Stores a pointer to the end of the container's populated contiguous memory.
-    object_type* m_end;
-    /// \brief Stores a pointer to the capacity limit of the container's contiguous memory.
-    object_type* m_capacity;
-
-    // MODIFIERS
+        // Store this container's original pointers in the other container.
+        other.m_begin = temp_begin;
+        other.m_end = temp_end;
+        other.m_capacity = temp_capacity;
+    }
     /// \brief Copy-assigns the contents of another container to this container.
     /// \param[in] other The other container to copy-assign from.
     /// \return A reference to this container.
@@ -229,24 +211,31 @@ protected:
 
         return *this;
     }
-    /// \brief Swaps the contents of this container with another container.
-    /// \param[in] other The other container to swap with.
-    void swap(std::container::dynamic::base<object_type>& other)
+
+    // CAPACITY
+    /// \brief Gets the size of the container.
+    /// \return The size of the container.
+    std::size_t size() const
     {
-        // Store this container's pointers in a temporary.
-        auto temp_begin = base::m_begin;
-        auto temp_end = base::m_end;
-        auto temp_capacity = base::m_capacity;
-
-        // Store the other container's pointers in this container.
-        base::m_begin = other.m_begin;
-        base::m_end = other.m_end;
-        base::m_capacity = other.m_capacity;
-
-        // Store this container's original pointers in the other container.
-        other.m_begin = temp_begin;
-        other.m_end = temp_end;
-        other.m_capacity = temp_capacity;
+        return base::m_end - base::m_begin;
+    }
+    /// \brief Gets the maximum capacity of the container.
+    /// \return The capacity of the container.
+    std::size_t capacity() const
+    {
+        return base::m_capacity - base::m_begin;
+    }
+    /// \brief Checks if the container is empty.
+    /// \return TRUE if the container is empty, otherwise FALSE.
+    bool empty() const
+    {
+        return base::m_end == base::m_begin;
+    }
+    /// \brief Checks if the container is at capacity.
+    /// \return TRUE if the container is at capacity, otherwise FALSE.
+    bool full() const
+    {
+        return base::m_end == base::m_capacity;
     }
 
     // COMPARISON
@@ -301,6 +290,15 @@ protected:
         return false;
     }
 
+protected:
+    // MEMORY
+    /// \brief Stores a pointer to the beginning of the container's contiguous memory.
+    object_type* m_begin;
+    /// \brief Stores a pointer to the end of the container's populated contiguous memory.
+    object_type* m_end;
+    /// \brief Stores a pointer to the capacity limit of the container's contiguous memory.
+    object_type* m_capacity;
+    
     // SHIFT
     /// \brief Shifts elements in the container left and reduces the size of the container.
     /// \param[in] position The position (inclusive) to begin the left-shift.

--- a/src/std/container/dynamic/map.hpp
+++ b/src/std/container/dynamic/map.hpp
@@ -122,6 +122,13 @@ public:
         return false;
     }
     using std::container::dynamic::base<std::pair<key_type,value_type>>::erase;
+    /// \brief Swaps the contents of this map with another map.
+    /// \param[in] other The other map to swap with.
+    void swap(std::map<key_type,value_type>* other)
+    {
+        // Use base container's swap function.
+        std::container::dynamic::base<std::pair<key_type,value_type>>::swap(other);
+    }
     /// \brief Copy-assigns the contents of another map to this map.
     /// \param[in] other The other map to copy-assign from.
     /// \return A reference to this map.
@@ -141,13 +148,6 @@ public:
         std::container::dynamic::base<std::pair<key_type,value_type>>::operator=(std::forward<std::map<key_type,value_type>>(other));
 
         return *this;
-    }
-    /// \brief Swaps the contents of this map with another map.
-    /// \param[in] other The other map to swap with.
-    void swap(std::map<key_type,value_type>* other)
-    {
-        // Use base container's swap function.
-        std::container::dynamic::base<std::pair<key_type,value_type>>::swap(other);
     }
 
     // COMPARISON

--- a/src/std/container/dynamic/map.hpp
+++ b/src/std/container/dynamic/map.hpp
@@ -32,7 +32,7 @@ public:
     /// \brief Move-constructs a map instance from another map.
     /// \param[in] other The other map to move-construct from.
     map(std::map<key_type,value_type>&& other)
-        : std::container::dynamic::base<std::pair<key_type,value_type>>(std::forward(other))
+        : std::container::dynamic::base<std::pair<key_type,value_type>>(std::forward<std::map<key_type,value_type>>(other))
     {}
 
     // LOOKUP
@@ -122,13 +122,25 @@ public:
         return false;
     }
     using std::container::dynamic::base<std::pair<key_type,value_type>>::erase;
-    /// \brief Copy-assigns the contents of this map from another map.
+    /// \brief Copy-assigns the contents of another map to this map.
     /// \param[in] other The other map to copy-assign from.
-    /// \return TRUE if the assignment succeeded, otherwise FALSE.
-    bool operator=(const std::map<key_type,value_type>& other)
+    /// \return A reference to this map.
+    std::map<key_type,value_type>& operator=(const std::map<key_type,value_type>& other)
     {
         // Use base container's operator= function.
-        return std::container::dynamic::base<std::pair<key_type,value_type>>::operator=(other);
+        std::container::dynamic::base<std::pair<key_type,value_type>>::operator=(other);
+
+        return *this;
+    }
+    /// \brief Move-assigns the contents of another map to this map.
+    /// \param[in] other The other map to move-assign from.
+    /// \return A reference to this map.
+    std::map<key_type,value_type>& operator=(std::map<key_type,value_type>&& other)
+    {
+        // Use base container's operator= function.
+        std::container::dynamic::base<std::pair<key_type,value_type>>::operator=(std::forward<std::map<key_type,value_type>>(other));
+
+        return *this;
     }
     /// \brief Swaps the contents of this map with another map.
     /// \param[in] other The other map to swap with.

--- a/src/std/container/dynamic/set.hpp
+++ b/src/std/container/dynamic/set.hpp
@@ -31,7 +31,7 @@ public:
     /// \brief Move-constructs a new set from an existing set.
     /// \param[in] other The other set to move-construct from.
     set(std::set<object_type>&& other)
-        : std::container::dynamic::base<object_type>(std::forward(other))
+        : std::container::dynamic::base<object_type>(std::forward<std::set<object_type>>(other))
     {}
 
     // LOOKUP
@@ -134,13 +134,25 @@ public:
         return false;
     }
     using std::container::dynamic::base<object_type>::erase;
-    /// \brief Copy-assigns the contents of this set from another set.
+    /// \brief Copy-assigns the contents of another set to this set.
     /// \param[in] other The other set to copy-assign from.
-    /// \return TRUE if the assignment succeeded, otherwise FALSE.
-    bool operator=(const std::set<object_type>& other)
+    /// \return A reference to this set.
+    std::set<object_type>& operator=(const std::set<object_type>& other)
     {
         // Use base container's operator= function.
-        return std::container::dynamic::base<object_type>::operator=(other);
+        std::container::dynamic::base<object_type>::operator=(other);
+
+        return *this;
+    }
+    /// \brief Move-assigns the contents of another set to this set.
+    /// \param[in] other The other set to move-assign from.
+    /// \return A reference to this set.
+    std::set<object_type>& operator=(std::set<object_type>&& other)
+    {
+        // Use base container's operator= function.
+        std::container::dynamic::base<object_type>::operator=(std::forward<std::set<object_type>>(other));
+
+        return *this;
     }
     /// \brief Swaps the contents of this set with another set.
     /// \param[in] other The other set to swap with.

--- a/src/std/container/dynamic/set.hpp
+++ b/src/std/container/dynamic/set.hpp
@@ -134,6 +134,13 @@ public:
         return false;
     }
     using std::container::dynamic::base<object_type>::erase;
+    /// \brief Swaps the contents of this set with another set.
+    /// \param[in] other The other set to swap with.
+    void swap(std::set<object_type>* other)
+    {
+        // Use base container's swap function.
+        std::container::dynamic::base<object_type>::swap(other);
+    }
     /// \brief Copy-assigns the contents of another set to this set.
     /// \param[in] other The other set to copy-assign from.
     /// \return A reference to this set.
@@ -153,13 +160,6 @@ public:
         std::container::dynamic::base<object_type>::operator=(std::forward<std::set<object_type>>(other));
 
         return *this;
-    }
-    /// \brief Swaps the contents of this set with another set.
-    /// \param[in] other The other set to swap with.
-    void swap(std::set<object_type>* other)
-    {
-        // Use base container's swap function.
-        std::container::dynamic::base<object_type>::swap(other);
     }
 
     // COMPARISON

--- a/src/std/container/dynamic/vector.hpp
+++ b/src/std/container/dynamic/vector.hpp
@@ -249,6 +249,13 @@ public:
         // Indicate success.
         return true;
     }
+    /// \brief Swaps the contents of this vector with another vector.
+    /// \param[in] other The other vector to swap with.
+    void swap(std::vector<object_type>& other)
+    {
+        // Use base container's swap method.
+        std::container::dynamic::base<object_type>::swap(other);
+    }
     /// \brief Copy-assigns the contents of another vector to this vector.
     /// \param[in] other The other vector to copy-assign from.
     /// \return A reference to this vector.
@@ -269,14 +276,7 @@ public:
 
         return *this;
     }
-    /// \brief Swaps the contents of this vector with another vector.
-    /// \param[in] other The other vector to swap with.
-    void swap(std::vector<object_type>& other)
-    {
-        // Use base container's swap method.
-        std::container::dynamic::base<object_type>::swap(other);
-    }
-
+    
     // COMPARISON
     /// \brief Checks if this vector is equal to another vector.
     /// \param[in] other The other vector to compare with.

--- a/src/std/container/dynamic/vector.hpp
+++ b/src/std/container/dynamic/vector.hpp
@@ -30,7 +30,7 @@ public:
     /// \brief Move-constructs a new vector from an existing vector.
     /// \param[in] other The other vector to move-construct from.
     vector(std::vector<object_type>&& other)
-        : std::container::dynamic::base<object_type>(std::forward(other))
+        : std::container::dynamic::base<object_type>(std::forward<std::vector<object_type>>(other))
     {}
 
     // ACCESS
@@ -249,13 +249,25 @@ public:
         // Indicate success.
         return true;
     }
-    /// \brief Copy-assigns the contents of this vector from another vector.
+    /// \brief Copy-assigns the contents of another vector to this vector.
     /// \param[in] other The other vector to copy-assign from.
-    /// \return TRUE if the assignment succeeded, FALSE if this vector does not have enough capacity.
-    bool operator=(const std::vector<object_type>& other)
+    /// \return A reference to this vector.
+    std::vector<object_type>& operator=(const std::vector<object_type>& other)
     {
         // Use base container's operator= method.
-        return std::container::dynamic::base<object_type>::operator=(other);
+        std::container::dynamic::base<object_type>::operator=(other);
+
+        return *this;
+    }
+    /// \brief Move-assigns the contents of another vector to this vector.
+    /// \param[in] other The other vector to move-assign from.
+    /// \return A reference to this vector.
+    std::vector<object_type>& operator=(std::vector<object_type>&& other)
+    {
+        // Use base container's operator= method.
+        std::container::dynamic::base<object_type>::operator=(std::forward<std::vector<object_type>>(other));
+
+        return *this;
     }
     /// \brief Swaps the contents of this vector with another vector.
     /// \param[in] other The other vector to swap with.

--- a/src/std/container/fixed/array.hpp
+++ b/src/std/container/fixed/array.hpp
@@ -93,22 +93,6 @@ public:
     }
 
     // MODIFIERS
-    /// \brief Deep-copies another array into this array.
-    /// \param[in] other The other array to copy from.
-    /// \return A reference to this array.
-    std::array<object_type,size_value>& operator=(const std::array<object_type,size_value>& other)
-    {
-        // Iterate through both arrays.
-        auto this_entry = array::m_begin;
-        auto other_entry = other.m_begin;
-        while(this_entry < array::m_end)
-        {
-            // Copy value of other to this array.
-            *this_entry++ = *other_entry++;
-        }
-
-        return *this;
-    }
     /// \brief Assigns a specified value to all elements in the array.
     /// \param[in] value The value to assign.
     void fill(const object_type& value)
@@ -140,6 +124,22 @@ public:
             // Store temporary into this and increment this.
             *this_entry++ = temporary;
         }
+    }
+    /// \brief Deep-copies another array into this array.
+    /// \param[in] other The other array to copy from.
+    /// \return A reference to this array.
+    std::array<object_type,size_value>& operator=(const std::array<object_type,size_value>& other)
+    {
+        // Iterate through both arrays.
+        auto this_entry = array::m_begin;
+        auto other_entry = other.m_begin;
+        while(this_entry < array::m_end)
+        {
+            // Copy value of other to this array.
+            *this_entry++ = *other_entry++;
+        }
+
+        return *this;
     }
 
     // COMPARISON

--- a/src/std/container/fixed/base.hpp
+++ b/src/std/container/fixed/base.hpp
@@ -78,17 +78,6 @@ public:
         return base::m_end - base::m_begin;
     }
 
-protected:
-    // DATA
-    /// \brief Stores the container's data in a fixed size/location array.
-    object_type m_data[size_value];
-
-    // ITERATORS
-    /// \brief An iterator to the beginning of the data array.
-    object_type* const m_begin;
-    /// \brief An iterator to the end of the data array.
-    object_type* const m_end;
-
     // COMPARISON
     /// \brief Checks if this container is equal to another container.
     /// \param[in] other The other array to compare with.
@@ -130,6 +119,17 @@ protected:
         // Indicate equal.
         return false;
     }
+    
+protected:
+    // DATA
+    /// \brief Stores the container's data in a fixed size/location array.
+    object_type m_data[size_value];
+
+    // ITERATORS
+    /// \brief An iterator to the beginning of the data array.
+    object_type* const m_begin;
+    /// \brief An iterator to the end of the data array.
+    object_type* const m_end;
 };
 
 }}

--- a/src/std/functional/function.hpp
+++ b/src/std/functional/function.hpp
@@ -87,8 +87,17 @@ public:
             delete function::m_callable;
         }
 
-        // Clone other function's callable into this function's callable.
-        function::m_callable = other.m_callable->clone();
+        // Check if other function's callable is valid.
+        if(other.m_callable)
+        {
+            // Clone other function's callable into this function's callable.
+            function::m_callable = other.m_callable->clone();
+        }
+        else
+        {
+            // Assign nullptr to this function's callable.
+            function::m_callable = nullptr;
+        }
 
         return *this;
     }

--- a/src/std/memory/smart_ptr/base.hpp
+++ b/src/std/memory/smart_ptr/base.hpp
@@ -87,13 +87,6 @@ public:
         return base::m_instance != nullptr;
     }
     
-protected:
-    template <typename other_type>
-    friend class base;
-
-    /// \brief The raw instance managed by this smart_ptr.
-    object_type* m_instance;
-
     // COMPARISON
     /// \brief Checks if this smart_ptr manages the same object as another smart_ptr.
     /// \tparam other_type The object type of the other smart_ptr. If different from this smart_ptr, the object type must be implicitly convertible.
@@ -113,6 +106,13 @@ protected:
     {
         return base::m_instance != other.m_instance;
     }
+    
+protected:
+    template <typename other_type>
+    friend class base;
+
+    /// \brief The raw instance managed by this smart_ptr.
+    object_type* m_instance;
 };
 
 }}}

--- a/src/std/memory/smart_ptr/base.hpp
+++ b/src/std/memory/smart_ptr/base.hpp
@@ -97,6 +97,13 @@ public:
     {
         return base::m_instance == other.m_instance;
     }
+    /// \brief Checks if this smart_ptr's internally managed pointer is equal to nullptr.
+    /// \return TRUE if this smart_ptr's internal pointer is equal to nullptr, otherwise FALSE.
+    bool operator==(decltype(nullptr)) const
+    {
+        // Compare managed pointer with raw pointer.
+        return base::m_instance == nullptr;
+    }
     /// \brief Checks if this smart_ptr manages a different object from another smart_ptr.
     /// \tparam other_type The object type of the other smart_ptr. If different from this smart_ptr, the object type must be implicitly convertible.
     /// \param[in] other The other smart_ptr.
@@ -105,6 +112,13 @@ public:
     bool operator!=(const std::memory::smart_ptr::base<other_type>& other) const
     {
         return base::m_instance != other.m_instance;
+    }
+    /// \brief Checks if this smart_ptr's internally managed pointer is not equal to nullptr.
+    /// \return TRUE if this smart_ptr's internal pointer is not equal to nullptr, otherwise FALSE.
+    bool operator!=(decltype(nullptr)) const
+    {
+        // Compare managed pointer with raw pointer.
+        return base::m_instance != nullptr;
     }
     
 protected:

--- a/src/std/memory/smart_ptr/shared_ptr.hpp
+++ b/src/std/memory/smart_ptr/shared_ptr.hpp
@@ -51,7 +51,7 @@ public:
     /// \brief Move-constructs a shared_ptr instance from another shared_ptr.
     /// \param[in] other The other shared_ptr instance to move.
     shared_ptr(std::shared_ptr<object_type>&& other)
-        : std::memory::smart_ptr::base<object_type>(std::forward(other)),
+        : std::memory::smart_ptr::base<object_type>(std::forward<std::shared_ptr<object_type>>(other)),
           m_reference_count(other.m_reference_count)
     {
         // Remove reference count from other.
@@ -64,7 +64,7 @@ public:
     /// \param[in] other The other shared_ptr instance to move.
     template <class other_type>
     shared_ptr(std::shared_ptr<other_type>&& other)
-        : std::memory::smart_ptr::base<object_type>(std::forward(other)),
+        : std::memory::smart_ptr::base<object_type>(std::forward<std::shared_ptr<other_type>>(other)),
           m_reference_count(other.m_reference_count)
     {
         // Remove reference count from other.

--- a/src/std/memory/smart_ptr/shared_ptr.hpp
+++ b/src/std/memory/smart_ptr/shared_ptr.hpp
@@ -212,6 +212,42 @@ public:
         return *shared_ptr::m_reference_count;
     }
 
+    // COMPARISON
+    /// \brief Checks if this shared_ptr is equal to another shared_ptr.
+    /// \tparam other_type The object type of the other shared_ptr. If different from this shared_ptr, the object must be implicitly convertible.
+    /// \param[in] other The other shared_ptr to compare with.
+    /// \return TRUE if the two shared_ptrs are equal, otherwise FALSE.
+    template <class other_type>
+    bool operator==(const std::shared_ptr<other_type>& other) const
+    {
+        // Use base smart_ptr comparison.
+        return std::memory::smart_ptr::base<object_type>::operator==(other);
+    }
+    /// \brief Checks if this shared_ptr's internally managed pointer is equal to nullptr.
+    /// \return TRUE if this shared_ptr's internal pointer is equal to nullptr, otherwise FALSE.
+    bool operator==(decltype(nullptr)) const
+    {
+        // Use base smart_ptr comparison.
+        return std::memory::smart_ptr::base<object_type>::operator==(nullptr);
+    }
+    /// \brief Checks if this shared_ptr is not equal to another shared_ptr.
+    /// \tparam other_type The object type of the other shared_ptr. If different from this shared_ptr, the object must be implicitly convertible.
+    /// \param[in] other The other shared_ptr to compare with.
+    /// \return TRUE if the two shared_ptrs are not equal, otherwise FALSE.
+    template <class other_type>
+    bool operator!=(const std::shared_ptr<other_type>& other) const
+    {
+        // Use base smart_ptr comparison.
+        return std::memory::smart_ptr::base<object_type>::operator!=(other);
+    }
+    /// \brief Checks if this shared_ptr's internally managed pointer is not equal to nullptr.
+    /// \return TRUE if this shared_ptr's internal pointer is not equal to nullptr, otherwise FALSE.
+    bool operator!=(decltype(nullptr)) const
+    {
+        // Use base smart_ptr comparison.
+        return std::memory::smart_ptr::base<object_type>::operator!=(nullptr);
+    }
+
 private:
     // FRIENDS
     template <typename other_type>

--- a/src/std/memory/smart_ptr/unique_ptr.hpp
+++ b/src/std/memory/smart_ptr/unique_ptr.hpp
@@ -124,6 +124,42 @@ public:
         return *this;
     }
 
+    // COMPARISON
+    /// \brief Checks if this unique_ptr is equal to another unique_ptr.
+    /// \tparam other_type The object type of the other unique_ptr. If different from this unique_ptr, the object must be implicitly convertible.
+    /// \param[in] other The other unique_ptr to compare with.
+    /// \return TRUE if the two unique_ptrs are equal, otherwise FALSE.
+    template <class other_type>
+    bool operator==(const std::unique_ptr<other_type>& other) const
+    {
+        // Use base smart_ptr comparison.
+        return std::memory::smart_ptr::base<object_type>::operator==(other);
+    }
+    /// \brief Checks if this unique_ptr's internally managed pointer is equal to nullptr.
+    /// \return TRUE if this unique_ptr's internal pointer is equal to nullptr, otherwise FALSE.
+    bool operator==(decltype(nullptr)) const
+    {
+        // Use base smart_ptr comparison.
+        return std::memory::smart_ptr::base<object_type>::operator==(nullptr);
+    }
+    /// \brief Checks if this unique_ptr is not equal to another unique_ptr.
+    /// \tparam other_type The object type of the other unique_ptr. If different from this unique_ptr, the object must be implicitly convertible.
+    /// \param[in] other The other unique_ptr to compare with.
+    /// \return TRUE if the two unique_ptrs are not equal, otherwise FALSE.
+    template <class other_type>
+    bool operator!=(const std::unique_ptr<other_type>& other) const
+    {
+        // Use base smart_ptr comparison.
+        return std::memory::smart_ptr::base<object_type>::operator!=(other);
+    }
+    /// \brief Checks if this unique_ptr's internally managed pointer is not equal to nullptr.
+    /// \return TRUE if this unique_ptr's internal pointer is not equal to nullptr, otherwise FALSE.
+    bool operator!=(decltype(nullptr)) const
+    {
+        // Use base smart_ptr comparison.
+        return std::memory::smart_ptr::base<object_type>::operator!=(nullptr);
+    }
+
 private:
     // FRIENDSHIP
     template <class other_type>

--- a/src/std/memory/smart_ptr/unique_ptr.hpp
+++ b/src/std/memory/smart_ptr/unique_ptr.hpp
@@ -29,7 +29,7 @@ public:
     /// \brief Move-constructs a unique_ptr instance from another unique_ptr.
     /// \param[in] other The other unique_ptr instance to move.
     unique_ptr(std::unique_ptr<object_type>&& other)
-        : std::memory::smart_ptr::base<object_type>(std::forward<std::unique_ptr<object_type>>(other.m_instance))
+        : std::memory::smart_ptr::base<object_type>(std::forward<std::unique_ptr<object_type>>(other))
     {
         // Remove instance from other.
         other.m_instance = nullptr;
@@ -39,7 +39,7 @@ public:
     /// \param[in] other The other unique_ptr instance to move.
     template <class other_type>
     unique_ptr(std::unique_ptr<other_type>&& other)
-        : std::memory::smart_ptr::base<object_type>(std::forward<std::unique_ptr<other_type>>(other.m_instance))
+        : std::memory::smart_ptr::base<object_type>(std::forward<std::unique_ptr<other_type>>(other))
     {
         // Remove instance from other.
         other.m_instance = nullptr;

--- a/src/std/memory/smart_ptr/unique_ptr.hpp
+++ b/src/std/memory/smart_ptr/unique_ptr.hpp
@@ -29,7 +29,7 @@ public:
     /// \brief Move-constructs a unique_ptr instance from another unique_ptr.
     /// \param[in] other The other unique_ptr instance to move.
     unique_ptr(std::unique_ptr<object_type>&& other)
-        : std::memory::smart_ptr::base<object_type>(std::forward(other.m_instance))
+        : std::memory::smart_ptr::base<object_type>(std::forward<std::unique_ptr<object_type>>(other.m_instance))
     {
         // Remove instance from other.
         other.m_instance = nullptr;
@@ -39,7 +39,7 @@ public:
     /// \param[in] other The other unique_ptr instance to move.
     template <class other_type>
     unique_ptr(std::unique_ptr<other_type>&& other)
-        : std::memory::smart_ptr::base<object_type>(std::forward(other.m_instance))
+        : std::memory::smart_ptr::base<object_type>(std::forward<std::unique_ptr<other_type>>(other.m_instance))
     {
         // Remove instance from other.
         other.m_instance = nullptr;

--- a/src/std/utility/forward.hpp
+++ b/src/std/utility/forward.hpp
@@ -3,6 +3,9 @@
 #ifndef STD___UTILITY___FORWARD_H
 #define STD___UTILITY___FORWARD_H
 
+// std
+#include <std/utility/remove_reference.hpp>
+
 namespace std {
 
 /// \brief Forwards a value while maintaining its value category.
@@ -10,10 +13,10 @@ namespace std {
 /// \param[in] object The object to forward.
 /// \return The value with it's value category preserved.
 template <typename object_type>
-object_type&& forward(object_type& object)
+typename std::remove_reference<object_type>::type&& forward(object_type& object)
 {
     // Convert the object to an r_value reference.
-    return static_cast<object_type&&>(object);
+    return static_cast<typename std::remove_reference<object_type>::type&&>(object);
 }
 
 }

--- a/src/std/utility/move.hpp
+++ b/src/std/utility/move.hpp
@@ -3,6 +3,9 @@
 #ifndef STD___UTILITY___MOVE_H
 #define STD___UTILITY___MOVE_H
 
+// std
+#include <std/utility/remove_reference.hpp>
+
 namespace std {
 
 /// \brief Converts an object to an r_value reference to be moved.
@@ -10,10 +13,10 @@ namespace std {
 /// \param[in] object The object to convert to an r_value reference.
 /// \return An r_value reference to the object.
 template <typename object_type>
-object_type&& move(object_type& object)
+typename std::remove_reference<object_type>::type&& move(object_type& object)
 {
     // Convert the object to an r_value reference.
-    return static_cast<object_type&&>(object);
+    return static_cast<typename std::remove_reference<object_type>::type&&>(object);
 }
 
 }

--- a/src/std/utility/remove_reference.hpp
+++ b/src/std/utility/remove_reference.hpp
@@ -1,0 +1,37 @@
+/// \file std/utility/remove_reference.hpp
+/// \brief Defines the std::remove_reference template function.
+#ifndef STD___UTILITY___REMOVE_REFERENCE_H
+#define STD___UTILITY___REMOVE_REFERENCE_H
+
+namespace std {
+
+/// \brief Removes lvalue and rvalue references from an object type.
+/// \tparam object_type The type of the object to remove references from.
+template <typename object_type>
+struct remove_reference
+{
+    /// \brief Captures the object type with lvalue and rvalue references removed.
+    using type = object_type;
+};
+
+/// \brief Removes lvalue and rvalue references from an object type.
+/// \tparam object_type The type of the object to remove references from.
+template <typename object_type>
+struct remove_reference<object_type&>
+{
+    /// \brief Captures the object type with lvalue and rvalue references removed.
+    using type = object_type;
+};
+
+/// \brief Removes lvalue and rvalue references from an object type.
+/// \tparam object_type The type of the object to remove references from.
+template <typename object_type>
+struct remove_reference<object_type&&>
+{
+    /// \brief Captures the object type with lvalue and rvalue references removed.
+    using type = object_type;
+};
+
+}
+
+#endif

--- a/test/unit/container_dynamic_base.cpp
+++ b/test/unit/container_dynamic_base.cpp
@@ -71,12 +71,23 @@ struct derived
             *entry = value;
         }
     }
-    /// \brief Exposes the underlying base::operator= function.
-    /// \param[in] other The other derived instance to assign from.
-    /// \return TRUE if the assignment succeeded, otherwise FALSE.
-    bool operator=(const derived& other)
+    /// \brief Exposes the underlying base::operator= copy function.
+    /// \param[in] other The other derived instance to copy-assign from.
+    /// \return A reference to this derived container.
+    derived& operator=(const derived& other)
     {
-        return std::container::dynamic::base<uint8_t>::operator=(other);
+        std::container::dynamic::base<uint8_t>::operator=(other);
+
+        return *this;
+    }
+    /// \brief Exposes the underlying base::operator= move function.
+    /// \param[in] other The other derived instance to move-assign from.
+    /// \return A reference to this derived container.
+    derived& operator=(derived&& other)
+    {
+        std::container::dynamic::base<uint8_t>::operator=(std::forward<derived>(other));
+
+        return *this;
     }
     /// \brief Exposes the underlying base::swap function.
     /// \param[in] other The other derived instance to swap with.
@@ -335,35 +346,36 @@ test(container_dynamic_base, clear)
     // Verify container is empty.
     assertTrue(container.empty());
 }
-/// \brief Tests the std::container::dynamic::base::operator= function with a valid configuration.
-test(container_dynamic_base, operator_assignment)
+/// \brief Tests the std::container::dynamic::base::operator= copy function.
+test(container_dynamic_base, operator_assign_copy)
 {
     // Create two containers.
-    derived container_a(5), container_b(5);
+    derived container_a(10), container_b(5);
 
     // Populate container_a.
     container_a.fill(container_a.capacity());
 
-    // Set container_b equal to container_a.
-    assertTrue(container_b = container_a);
+    // Copy-assign container_a to container_b.
+    container_b = container_a;
 
     // Verify containers are equal.
     assertTrue(container_b == container_a);
 }
-/// \brief Tests the std::container::dynamic::base::operator= function with not enough capacity.
-test(container_dynamic_base, operator_assignment_over_capacity)
+/// \brief Tests the std::container::dynamic::base::operator= move function.
+test(container_dynamic_base, operator_assign_move)
 {
-    // Create two containers, with container_b having smaller capacity.
-    derived container_a(5), container_b(3);
+    // Create two containers.
+    derived container_a(10), container_b(5);
 
     // Populate container_a.
     container_a.fill(container_a.capacity());
 
-    // Verify setting container_b equal to container_a fails.
-    assertFalse(container_b = container_a);
+    // Move-assign container_a into container_b
+    container_b = std::move(container_a);
 
-    // Verify container_b is still empty.
-    assertTrue(container_b.empty());
+    // Verify container_b is now populated.
+    assertEqual(container_b.capacity(), std::size_t(10));
+    assertEqual(container_b.size(), std::size_t(10));
 }
 /// \brief Tests the std::container::dynamic::base::swap function.
 test(container_dynamic_base, swap)

--- a/test/unit/container_dynamic_base.cpp
+++ b/test/unit/container_dynamic_base.cpp
@@ -571,6 +571,29 @@ test(container_dynamic_base, shift_left)
         assertEqual(*(container.cbegin() + i), expected[i]);
     }
 }
+/// \brief Tests the std::container::dynamic::base::shift_left function with an end() position.
+test(container_dynamic_base, shift_left_end)
+{
+    // Specify container elements after shift.
+    // Assumes original container is {0,1,2,3,4}, with position = end, count = 3.
+    uint8_t expected[2] = {0,1};
+
+    // Create and fill a container.
+    derived container(5);
+    container.fill(container.capacity());
+
+    // Shift the end position left.
+    assertTrue(container.shift_left(container.end(), 3));
+
+    // Verify reduced size.
+    assertEqual(container.size(), std::size_t(2));
+
+    // Verify container contents after shift.
+    for(uint8_t i = 0; i < container.size(); ++i)
+    {
+        assertEqual(*(container.cbegin() + i), expected[i]);
+    }
+}
 /// \brief Tests the std::container::dynamic::base::shift_left function with an empty container.
 test(container_dynamic_base, shift_left_empty)
 {
@@ -594,7 +617,7 @@ test(container_dynamic_base, shift_left_invalid_position)
     assertEqual(container.size(), std::size_t(3));
 
     // Shift left with position past end and verify failure.
-    assertFalse(container.shift_left(container.end(), 1));
+    assertFalse(container.shift_left(container.end() + 1, 1));
 
     // Verify size did not change.
     assertEqual(container.size(), std::size_t(3));
@@ -633,6 +656,30 @@ test(container_dynamic_base, shift_right)
     for(uint8_t i = 0; i < container.size(); ++i)
     {
         assertEqual(*(container.cbegin() + i), expected[i]);
+    }
+}
+/// \brief Tests the std::container::dynamic::base::shift_right function with an end() position.
+test(container_dynamic_base, shift_right_end)
+{
+    // Specify capacity and original size.
+    const std::size_t capacity = 10;
+    const std::size_t original_size = 5;
+    const std::size_t shift_size = 3;
+
+    // Create and fill a container partway.
+    derived container(capacity);
+    container.fill(original_size);
+
+    // Shift the end position right.
+    assertTrue(container.shift_right(container.end(), shift_size));
+
+    // Verify increased size.
+    assertEqual(container.size(), original_size + shift_size);
+
+    // Verify original container contents after shift.
+    for(uint8_t i = 0; i < original_size; ++i)
+    {
+        assertEqual(*(container.cbegin() + i), i);
     }
 }
 /// \brief Tests the std::container::dynamic::base::shift_right function with an empty container.

--- a/test/unit/functional_function.cpp
+++ b/test/unit/functional_function.cpp
@@ -156,6 +156,24 @@ test(functional_function, operator_assign_copy)
     // Verify function_b is now valid.
     assertTrue(function_b);
 }
+/// \brief Tests the std::function::operator= copy function with an empty function.
+test(functional_function, operator_assign_copy_empty)
+{
+    // Construct an empty function.
+    std::function<uint8_t(uint8_t)> function_a;
+
+    // Construct an std::function with a global function pointer.
+    std::function<uint8_t(uint8_t)> function_b(&test_function);
+
+    // Copy assign function_a to function_b.
+    function_b = function_a;
+
+    // Verify function_a is invalid.
+    assertFalse(function_a);
+
+    // Verify function_b is now invalid.
+    assertFalse(function_b);
+}
 /// \brief Tests the std::function::operator= move function.
 test(functional_function, operator_assign_move)
 {

--- a/test/unit/memory_smart_ptr_base.cpp
+++ b/test/unit/memory_smart_ptr_base.cpp
@@ -250,6 +250,30 @@ test(memory_smart_ptr_base, operator_equal_unequal)
     // Clean up raw pointer.
     delete raw_pointer;
 }
+/// \brief Tests the std::memory::smart_ptr::operator== function when equal to nullptr.
+test(memory_smart_ptr_base, operator_equal_nullptr_equal)
+{
+    // Construct an empty smart_ptr.
+    derived smart_ptr(nullptr);
+
+    // Verify operator== returns true.
+    assertTrue(smart_ptr == nullptr);
+}
+/// \brief Tests the std::memory::smart_ptr::operator== function when not equal to nullptr.
+test(memory_smart_ptr_base, operator_equal_nullptr_unequal)
+{
+    // Create a raw pointer.
+    uint8_t* const raw_pointer = new uint8_t(0x12);
+
+    // Construct a smart_ptr from the raw pointer.
+    derived smart_ptr(raw_pointer);
+
+    // Verify operator== returns false.
+    assertFalse(smart_ptr == nullptr);
+
+    // Clean up raw pointer.
+    delete raw_pointer;
+}
 /// \brief Tests the std::memory::smart_ptr::operator!= function with equal smart_ptrs.
 test(memory_smart_ptr_base, operator_not_equal_equal)
 {
@@ -276,6 +300,30 @@ test(memory_smart_ptr_base, operator_not_equal_unequal)
 
     // Verify operator!= returns true.
     assertTrue(smart_ptr_a != smart_ptr_b);
+
+    // Clean up raw pointer.
+    delete raw_pointer;
+}
+/// \brief Tests the std::memory::smart_ptr::operator!= function when equal to nullptr.
+test(memory_smart_ptr_base, operator_not_equal_nullptr_equal)
+{
+    // Construct an empty smart_ptr.
+    derived smart_ptr(nullptr);
+
+    // Verify operator!= returns false.
+    assertFalse(smart_ptr != nullptr);
+}
+/// \brief Tests the std::memory::smart_ptr::operator!= function when not equal to nullptr.
+test(memory_smart_ptr_base, operator_not_equal_nullptr_unequal)
+{
+    // Create a raw pointer.
+    uint8_t* const raw_pointer = new uint8_t(0x12);
+
+    // Construct a smart_ptr from the raw pointer.
+    derived smart_ptr(raw_pointer);
+
+    // Verify operator!= returns true.
+    assertTrue(smart_ptr != nullptr);
 
     // Clean up raw pointer.
     delete raw_pointer;


### PR DESCRIPTION
- `std::function`: fixed bug to allow operator= to handle copying from an empty `std::function`
- `std::container::dynamic::base`: fixed bug in shift_left method for end position handling
- `std::container::dynamic`: added move assignment and fixed missing returns
- `std::memory`: fixed bug to enable perfect forwarding in move constructor/assignment
- `std::memory`: added comparison operators to all components
- `std::utility`: added `std::remove_reference` to better facilitate perfect forwarding
- Rearranged assignment and comparison operator code for cleanup across multiple components